### PR TITLE
Form validation

### DIFF
--- a/src/@types/board.d.ts
+++ b/src/@types/board.d.ts
@@ -4,12 +4,6 @@ type Row = Square[];
 type Board = Row[];
 
 type Coords = {
-  row: number,
-  col: number,
-};
-
-type BoardProps = {
-  data: Board,
-  handlePlayerInput: (coords: Coords) => void,
-  reset: () => void,
+  row: number;
+  col: number;
 };

--- a/src/@types/board.d.ts
+++ b/src/@types/board.d.ts
@@ -6,9 +6,10 @@ type Board = Row[];
 type Coords = {
   row: number,
   col: number,
-}
+};
 
 type BoardProps = {
   data: Board,
   handlePlayerInput: (coords: Coords) => void,
-}
+  reset: () => void,
+};

--- a/src/@types/reactProps.d.ts
+++ b/src/@types/reactProps.d.ts
@@ -7,5 +7,5 @@ type BoardProps = {
 type BoardFormProps = {
   handleChange: (event: React.FormEvent<HTMLInputElement>) => void;
   handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  error: boolean;
+  hasError: boolean;
 };

--- a/src/@types/reactProps.d.ts
+++ b/src/@types/reactProps.d.ts
@@ -1,0 +1,5 @@
+type BoardProps = {
+  data: Board;
+  handlePlayerInput: (coords: Coords) => void;
+  reset: () => void;
+};

--- a/src/@types/reactProps.d.ts
+++ b/src/@types/reactProps.d.ts
@@ -3,3 +3,9 @@ type BoardProps = {
   handlePlayerInput: (coords: Coords) => void;
   reset: () => void;
 };
+
+type BoardFormProps = {
+  handleChange: (event: React.FormEvent<HTMLInputElement>) => void;
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  error: boolean;
+};

--- a/src/@types/reactState.d.ts
+++ b/src/@types/reactState.d.ts
@@ -1,0 +1,5 @@
+type GameState = {
+  board?: Board;
+  boardSize?: number;
+  error?: boolean;
+};

--- a/src/@types/reactState.d.ts
+++ b/src/@types/reactState.d.ts
@@ -1,5 +1,5 @@
 type GameState = {
   board?: Board;
   boardSize?: number;
-  error?: boolean;
+  hasError?: boolean;
 };

--- a/src/__tests__/GameBoard.test.tsx
+++ b/src/__tests__/GameBoard.test.tsx
@@ -7,7 +7,11 @@ describe('GameBoard component', () => {
   it('should render a table', () => {
     const boardArray = createBoard(3, undefined);
     const wrapper = shallow(
-      <GameBoard data={boardArray} handlePlayerInput={jest.fn()} />
+      <GameBoard
+        data={boardArray}
+        handlePlayerInput={jest.fn()}
+        reset={jest.fn()}
+      />
     );
     expect(wrapper.find('table#game-table').exists()).toBe(true);
   });
@@ -18,7 +22,11 @@ describe('GameBoard component', () => {
       .map(() => Array(5).fill(undefined));
 
     const wrapper = shallow(
-      <GameBoard data={testBoard} handlePlayerInput={jest.fn()} />
+      <GameBoard
+        data={testBoard}
+        handlePlayerInput={jest.fn()}
+        reset={jest.fn()}
+      />
     );
     const squares = wrapper.find('.square');
     expect(squares).toHaveLength(25);
@@ -31,7 +39,11 @@ describe('GameBoard component', () => {
       ['X', 'O', 'X'],
     ];
     const wrapper = shallow(
-      <GameBoard data={testBoard} handlePlayerInput={jest.fn()} />
+      <GameBoard
+        data={testBoard}
+        handlePlayerInput={jest.fn()}
+        reset={jest.fn()}
+      />
     );
     const squares = wrapper.find('.square');
     expect(squares).toHaveLength(9);

--- a/src/__tests__/TTTComponent.test.tsx
+++ b/src/__tests__/TTTComponent.test.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import TicTacToe from '../components/TicTacToe';
+
+describe('TTT component', () => {
+  it('should render title', () => {
+    const wrapper = shallow(<TicTacToe />);
+    expect(wrapper.contains(<h1>Tic Tac Toe</h1>)).toEqual(true);
+  });
+
+  it('should render the BoardSizeForm component by default', () => {
+    const wrapper = shallow(<TicTacToe />);
+    expect(wrapper.find('BoardSizeForm').exists()).toBe(true);
+  });
+});

--- a/src/__tests__/TicTacToe.test.tsx
+++ b/src/__tests__/TicTacToe.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import TicTacToe from '../components/TicTacToe';
 
-describe('TTT component', () => {
+describe('TicTacToe component', () => {
   it('should render title', () => {
     const wrapper = shallow(<TicTacToe />);
     expect(wrapper.contains(<h1>Tic Tac Toe</h1>)).toEqual(true);

--- a/src/components/BoardSizeForm.tsx
+++ b/src/components/BoardSizeForm.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { Error } from './index';
 
-type BoardFormProps = {
-  handleChange: (event: React.FormEvent<HTMLInputElement>) => void;
-  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  error: boolean;
-};
-
 const BoardSizeForm: React.SFC<BoardFormProps> = props => {
   const { handleChange, handleSubmit, error } = props;
   return (

--- a/src/components/BoardSizeForm.tsx
+++ b/src/components/BoardSizeForm.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type BoardFormProps = {
+  handleChange: (event: React.FormEvent<HTMLInputElement>) => void;
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+const BoardSizeForm: React.SFC<BoardFormProps> = props => {
+  const { handleChange, handleSubmit } = props;
+  return (
+    <React.Fragment>
+      <p>What size should the board be?</p>
+      <form onSubmit={handleSubmit}>
+        Board Size:
+        <input onChange={handleChange} type='text' name='size' />
+        <input type='submit' value='submit' />
+      </form>
+    </React.Fragment>
+  );
+};
+
+export default BoardSizeForm;

--- a/src/components/BoardSizeForm.tsx
+++ b/src/components/BoardSizeForm.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { Error } from './index';
+import Error from './Error';
 
 const BoardSizeForm: React.SFC<BoardFormProps> = props => {
   const { handleChange, handleSubmit, error } = props;
   return (
     <React.Fragment>
       <p>What size should the board be?</p>
-      <form onSubmit={handleSubmit}>
+      <form id='size-form' onSubmit={handleSubmit}>
         Board Size:
         <input onChange={handleChange} type='text' name='size' />
-        <input type='submit' value='submit' />
+        <input id='size-submit' type='submit' value='submit' />
       </form>
       {error && <Error />}
     </React.Fragment>

--- a/src/components/BoardSizeForm.tsx
+++ b/src/components/BoardSizeForm.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
+import { Error } from './index';
 
 type BoardFormProps = {
   handleChange: (event: React.FormEvent<HTMLInputElement>) => void;
   handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  error: boolean;
 };
 
 const BoardSizeForm: React.SFC<BoardFormProps> = props => {
-  const { handleChange, handleSubmit } = props;
+  const { handleChange, handleSubmit, error } = props;
   return (
     <React.Fragment>
       <p>What size should the board be?</p>
@@ -15,6 +17,7 @@ const BoardSizeForm: React.SFC<BoardFormProps> = props => {
         <input onChange={handleChange} type='text' name='size' />
         <input type='submit' value='submit' />
       </form>
+      {error && <Error />}
     </React.Fragment>
   );
 };

--- a/src/components/BoardSizeForm.tsx
+++ b/src/components/BoardSizeForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Error from './Error';
 
 const BoardSizeForm: React.SFC<BoardFormProps> = props => {
-  const { handleChange, handleSubmit, error } = props;
+  const { handleChange, handleSubmit, hasError } = props;
   return (
     <React.Fragment>
       <p>What size should the board be?</p>
@@ -11,7 +11,7 @@ const BoardSizeForm: React.SFC<BoardFormProps> = props => {
         <input onChange={handleChange} type='text' name='size' />
         <input id='size-submit' type='submit' value='submit' />
       </form>
-      {error && <Error />}
+      {hasError && <Error />}
     </React.Fragment>
   );
 };

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+const Error: React.SFC<any> = props => {
+  return (
+    <div>
+      <p>Error: Invalid input. Please input a number from 3 - 10</p>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 const GameBoard: React.SFC<BoardProps> = props => {
-  const { data, handlePlayerInput } = props;
+  const { data, handlePlayerInput, reset } = props;
 
   return data ? (
     <div id='board'>
@@ -13,7 +13,9 @@ const GameBoard: React.SFC<BoardProps> = props => {
                 <td
                   key={columnIndex}
                   className='square'
-                  onClick={() => handlePlayerInput({row: rowIndex, col: columnIndex})}
+                  onClick={() =>
+                    handlePlayerInput({ row: rowIndex, col: columnIndex })
+                  }
                 >
                   {square || '•'}
                 </td>
@@ -22,6 +24,7 @@ const GameBoard: React.SFC<BoardProps> = props => {
           ))}
         </tbody>
       </table>
+      <button onClick={reset}>Reset</button>
     </div>
   ) : (
     <h1>NO_BOARD</h1>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -4,7 +4,7 @@ const GameBoard: React.SFC<BoardProps> = props => {
   const { data, handlePlayerInput, reset } = props;
 
   return data ? (
-    <div id='board'>
+    <div id='board' className='center column'>
       <table id='game-table'>
         <tbody>
           {data.map((row, rowIndex) => (

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Game from '../tic-tac-toe';
-import { GameBoard, BoardSizeForm } from './index';
+import GameBoard from './GameBoard';
+import BoardSizeForm from './BoardSizeForm';
 
 class TicTacToe extends React.Component<object, GameState> {
   private game: Game = new Game();

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -2,12 +2,6 @@ import * as React from 'react';
 import Game from '../tic-tac-toe';
 import { GameBoard, BoardSizeForm } from './index';
 
-type GameState = {
-  board?: Board;
-  boardSize?: number;
-  error?: boolean;
-};
-
 class TicTacToe extends React.Component<object, GameState> {
   private game: Game = new Game();
 
@@ -36,8 +30,6 @@ class TicTacToe extends React.Component<object, GameState> {
 
   public submitBoardSize = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    /* TODO: an undefined value should still pass, since a user should be able
-    to create a 3x3 by default. Maybe I need to set a default value in the actual form? */
     if (this.validateBoardSizeInput(this.state.boardSize)) {
       this.game = new Game(this.state.boardSize);
       this.setState({

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Game from '../tic-tac-toe';
-import GameBoard from './GameBoard';
+import { GameBoard, BoardSizeForm } from './index';
 
 type GameState = {
   board?: Board;
@@ -42,12 +42,10 @@ class TicTacToe extends React.Component<object, GameState> {
       <div className='container center'>
         <div className='center-container center column'>
           <h1>Tic Tac Toe</h1>
-          <p>What size should the board be?</p>
-          <form onSubmit={this.submitBoardSize}>
-            Board Size:
-            <input onChange={this.handleChange} type='text' name='size' />
-            <input type='submit' value='submit' />
-          </form>
+          <BoardSizeForm
+            handleChange={this.handleChange}
+            handleSubmit={this.submitBoardSize}
+          />
           {board ? (
             <GameBoard
               data={board}

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -5,7 +5,7 @@ import { GameBoard, BoardSizeForm } from './index';
 type GameState = {
   board?: Board;
   boardSize?: number;
-  error?: string;
+  error?: boolean;
 };
 
 class TicTacToe extends React.Component<object, GameState> {
@@ -14,13 +14,17 @@ class TicTacToe extends React.Component<object, GameState> {
   public state = {
     board: undefined,
     boardSize: undefined,
-    error: undefined,
+    error: false,
   };
 
-  private validateBoardSizeInput = (size: number = 0): boolean => {
+  private validateBoardSizeInput = (size?: number): boolean => {
+    if (size === undefined) {
+      return true;
+    }
+    const isNotNull = size !== null;
     const threeOrAbove = size >= 3;
     const elevenOrBelow = size <= 10;
-    const isValidInput = threeOrAbove && elevenOrBelow;
+    const isValidInput = threeOrAbove && elevenOrBelow && isNotNull;
     return isValidInput;
   };
 
@@ -32,6 +36,8 @@ class TicTacToe extends React.Component<object, GameState> {
 
   public submitBoardSize = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
+    /* TODO: an undefined value should still pass, since a user should be able
+    to create a 3x3 by default. Maybe I need to set a default value in the actual form? */
     if (this.validateBoardSizeInput(this.state.boardSize)) {
       this.game = new Game(this.state.boardSize);
       this.setState({
@@ -39,7 +45,7 @@ class TicTacToe extends React.Component<object, GameState> {
       });
     } else {
       this.setState({
-        error: 'Invalid input',
+        error: true,
       });
     }
   };
@@ -54,6 +60,7 @@ class TicTacToe extends React.Component<object, GameState> {
   public resetGame = (): void => {
     this.setState({
       board: undefined,
+      error: false,
     });
   };
 
@@ -67,6 +74,7 @@ class TicTacToe extends React.Component<object, GameState> {
             <BoardSizeForm
               handleChange={this.handleChange}
               handleSubmit={this.submitBoardSize}
+              error={this.state.error}
             />
           ) : (
             <GameBoard

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -42,17 +42,16 @@ class TicTacToe extends React.Component<object, GameState> {
       <div className='container center'>
         <div className='center-container center column'>
           <h1>Tic Tac Toe</h1>
-          <BoardSizeForm
-            handleChange={this.handleChange}
-            handleSubmit={this.submitBoardSize}
-          />
-          {board ? (
+          {!board ? (
+            <BoardSizeForm
+              handleChange={this.handleChange}
+              handleSubmit={this.submitBoardSize}
+            />
+          ) : (
             <GameBoard
               data={board}
               handlePlayerInput={this.handlePlayerInput}
             />
-          ) : (
-            <p> Start a new game</p>
           )}
         </div>
       </div>

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -12,14 +12,15 @@ class TicTacToe extends React.Component<object, GameState> {
     hasError: false,
   };
 
-  private validateBoardSizeInput = (size?: number): boolean => {
+  private validateBoardSizeInput = (): boolean => {
+    const size = this.state.boardSize;
     if (size === undefined) {
       return true;
     }
-    const isNotNull = size !== null;
+    const isPresent = size !== null;
     const threeOrAbove = size >= 3;
     const elevenOrBelow = size <= 10;
-    const isValidInput = threeOrAbove && elevenOrBelow && isNotNull;
+    const isValidInput = threeOrAbove && elevenOrBelow && isPresent;
     return isValidInput;
   };
 
@@ -31,7 +32,7 @@ class TicTacToe extends React.Component<object, GameState> {
 
   public submitBoardSize = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    if (this.validateBoardSizeInput(this.state.boardSize)) {
+    if (this.validateBoardSizeInput()) {
       this.game = new Game(this.state.boardSize);
       this.setState({
         board: this.game.board,

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -9,7 +9,7 @@ class TicTacToe extends React.Component<object, GameState> {
   public state = {
     board: undefined,
     boardSize: undefined,
-    error: false,
+    hasError: false,
   };
 
   private validateBoardSizeInput = (size?: number): boolean => {
@@ -38,7 +38,7 @@ class TicTacToe extends React.Component<object, GameState> {
       });
     } else {
       this.setState({
-        error: true,
+        hasError: true,
       });
     }
   };
@@ -53,7 +53,7 @@ class TicTacToe extends React.Component<object, GameState> {
   public resetGame = (): void => {
     this.setState({
       board: undefined,
-      error: false,
+      hasError: false,
     });
   };
 
@@ -67,7 +67,7 @@ class TicTacToe extends React.Component<object, GameState> {
             <BoardSizeForm
               handleChange={this.handleChange}
               handleSubmit={this.submitBoardSize}
-              error={this.state.error}
+              hasError={this.state.hasError}
             />
           ) : (
             <GameBoard

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -36,6 +36,12 @@ class TicTacToe extends React.Component<object, GameState> {
     });
   };
 
+  public resetGame = (): void => {
+    this.setState({
+      board: undefined,
+    });
+  };
+
   public render() {
     const { board } = this.state;
     return (
@@ -51,6 +57,7 @@ class TicTacToe extends React.Component<object, GameState> {
             <GameBoard
               data={board}
               handlePlayerInput={this.handlePlayerInput}
+              reset={this.resetGame}
             />
           )}
         </div>

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -5,7 +5,6 @@ import GameBoard from './GameBoard';
 type GameState = {
   board?: Board;
   boardSize?: number;
-  game?: Game;
 };
 
 class TicTacToe extends React.Component<object, GameState> {
@@ -14,7 +13,6 @@ class TicTacToe extends React.Component<object, GameState> {
   public state = {
     board: undefined,
     boardSize: undefined,
-    game: undefined,
   };
 
   public handleChange = (event: React.FormEvent<HTMLInputElement>): void => {

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -5,6 +5,7 @@ import { GameBoard, BoardSizeForm } from './index';
 type GameState = {
   board?: Board;
   boardSize?: number;
+  error?: string;
 };
 
 class TicTacToe extends React.Component<object, GameState> {
@@ -13,6 +14,14 @@ class TicTacToe extends React.Component<object, GameState> {
   public state = {
     board: undefined,
     boardSize: undefined,
+    error: undefined,
+  };
+
+  private validateBoardSizeInput = (size: number = 0): boolean => {
+    const threeOrAbove = size >= 3;
+    const elevenOrBelow = size <= 10;
+    const isValidInput = threeOrAbove && elevenOrBelow;
+    return isValidInput;
   };
 
   public handleChange = (event: React.FormEvent<HTMLInputElement>): void => {
@@ -23,10 +32,16 @@ class TicTacToe extends React.Component<object, GameState> {
 
   public submitBoardSize = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    this.game = new Game(this.state.boardSize);
-    this.setState({
-      board: this.game.board,
-    });
+    if (this.validateBoardSizeInput(this.state.boardSize)) {
+      this.game = new Game(this.state.boardSize);
+      this.setState({
+        board: this.game.board,
+      });
+    } else {
+      this.setState({
+        error: 'Invalid input',
+      });
+    }
   };
 
   public handlePlayerInput = (coords: Coords): void => {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
 export { default as TicTacToe } from './TicTacToe';
 export { default as GameBoard } from './GameBoard';
+export { default as BoardSizeForm } from './BoardSizeForm';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
 export { default as TicTacToe } from './TicTacToe';
 export { default as GameBoard } from './GameBoard';
 export { default as BoardSizeForm } from './BoardSizeForm';
-export { default as Error } from './Error.tsx';
+export { default as Error } from './Error';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export { default as TicTacToe } from './TicTacToe';
 export { default as GameBoard } from './GameBoard';
 export { default as BoardSizeForm } from './BoardSizeForm';
+export { default as Error } from './Error.tsx';


### PR DESCRIPTION
Fixes #17 

Add form validation to prevent users from typing in non-numerical values, and values outside the range 3-10.

## Main areas of change

### src/components/TicTacToe.tsx
Added `validateBoardSizeInput` method, which gets invoked by the `submitBoardSize` method. An invalid board sets `this.state.error` to be true, which is then conditionally rendered inside the `BoardSizeForm` component. 

### src/components/BoardSizeForm.tsx
Moved form into it's own component so it could be conditionally rendered

### src/components/Error.tsx
Created new component to display an error when form input is invalid

### @types
Separated type definitions into 3 different files

### src/__tests__/GameBoard.test.tsx
Had to start handing the `GameBoard` component a mock for the `reset` prop now that it's required.